### PR TITLE
deadlinedateを有効化

### DIFF
--- a/__test__/test.ts
+++ b/__test__/test.ts
@@ -489,7 +489,7 @@ describe("/tasks", () => {
     expect(res.body).toEqual([]);
   });
 
-  it("GET /authed/tasks/1", async () => {
+  it("GET /authed/tasks/1 (bad request)", async () => {
     const res = await req
       .get("/api/v1/authed/tasks/1")
       .set("Authorization", `Bearer ${bearerUser1}`)
@@ -498,7 +498,46 @@ describe("/tasks", () => {
     expect(res.body.errorCode).toBe(1610);
   });
 
-  it("POST /authed/tasks", async () => {
+  it("POST /authed/tasks only comment (bad request)", async () => {
+    const reqBody = {
+      comment: "taskComment"
+    };
+    const res = await req
+      .post("/api/v1/authed/tasks")
+      .set("Authorization", `Bearer ${bearerUser1}`)
+      .send(reqBody);
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(1605);
+  });
+
+  it("POST /authed/tasks name, commemt and deadlinedate(not ISO8601) (bad request)", async () => {
+    const reqBody = {
+      name: "taskName",
+      comment: "taskComment",
+      deadlinedate: "notISO8601String"
+    };
+    const res = await req
+      .post("/api/v1/authed/tasks")
+      .set("Authorization", `Bearer ${bearerUser1}`)
+      .send(reqBody);
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(1706);
+  });
+
+  it("POST /authed/tasks (user4, not belonged to any group) (bad request)", async () => {
+    const reqBody = {
+      name: "taskName",
+      comment: "taskComment"
+    };
+    const res = await req
+      .post("/api/v1/authed/tasks")
+      .set("Authorization", `Bearer ${bearerUser4}`)
+      .send(reqBody);
+    expect(res.status).toBe(500);
+    expect(res.body.errorCode).toEqual(1607);
+  });
+
+  it("POST /authed/tasks name", async () => {
     const reqBody = {
       name: "taskName"
     };
@@ -521,22 +560,11 @@ describe("/tasks", () => {
     });
   });
 
-  it("POST /authed/tasks only comment (wrong)", async () => {
-    const reqBody = {
-      comment: "taskComment"
-    };
-    const res = await req
-      .post("/api/v1/authed/tasks")
-      .set("Authorization", `Bearer ${bearerUser1}`)
-      .send(reqBody);
-    expect(res.status).toBe(400);
-    expect(res.body.errorCode).toBe(1605);
-  });
-
-  it("POST /authed/tasks name and commemt", async () => {
+  it("POST /authed/tasks name, comment and whoisdoinguserid", async () => {
     const reqBody = {
       name: "taskName",
-      comment: "taskComment"
+      comment: "taskComment",
+      whoisdoinguserid: 1
     };
     const res = await req
       .post("/api/v1/authed/tasks")
@@ -544,7 +572,7 @@ describe("/tasks", () => {
       .send(reqBody);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
-      whoisdoinguserid: null,
+      whoisdoinguserid: 1,
       isfinished: false,
       deadlinedate: null,
       finisheddate: null,
@@ -557,11 +585,12 @@ describe("/tasks", () => {
     });
   });
 
-  it("POST /authed/tasks name, comment and whoisdoinguserid", async () => {
+  it("POST /authed/tasks name, comment, whoisdoinguserid and deadlinedate", async () => {
     const reqBody = {
       name: "taskName",
       comment: "taskComment",
-      whoisdoinguserid: 2
+      whoisdoinguserid: 2,
+      deadlinedate: "2020-02-03T04:05:06.078Z"
     };
     const res = await req
       .post("/api/v1/authed/tasks")
@@ -571,7 +600,7 @@ describe("/tasks", () => {
     expect(res.body).toEqual({
       whoisdoinguserid: 2,
       isfinished: false,
-      deadlinedate: null,
+      deadlinedate: "2020-02-03T04:05:06.078Z",
       finisheddate: null,
       id: 3,
       name: "taskName",
@@ -580,19 +609,6 @@ describe("/tasks", () => {
       updatedAt: expect.anything(),
       createdAt: expect.anything()
     });
-  });
-
-  it("POST /authed/tasks (wrong, user4, not belonged to any group)", async () => {
-    const reqBody = {
-      name: "taskName",
-      comment: "taskComment"
-    };
-    const res = await req
-      .post("/api/v1/authed/tasks")
-      .set("Authorization", `Bearer ${bearerUser4}`)
-      .send(reqBody);
-    expect(res.status).toBe(500);
-    expect(res.body.errorCode).toEqual(1607);
   });
 
   it("GET /authed/tasks", async () => {
@@ -615,7 +631,7 @@ describe("/tasks", () => {
         createdAt: expect.anything()
       },
       {
-        whoisdoinguserid: null,
+        whoisdoinguserid: 1,
         isfinished: false,
         deadlinedate: null,
         finisheddate: null,
@@ -629,7 +645,7 @@ describe("/tasks", () => {
       {
         whoisdoinguserid: 2,
         isfinished: false,
-        deadlinedate: null,
+        deadlinedate: "2020-02-03T04:05:06.078Z",
         finisheddate: null,
         id: 3,
         name: "taskName",
@@ -637,7 +653,19 @@ describe("/tasks", () => {
         groupid: 1,
         updatedAt: expect.anything(),
         createdAt: expect.anything()
-      }
+      } /* ,
+      {
+        whoisdoinguserid: 2,
+        isfinished: false,
+        deadlinedate: "2020-02-03T04:05:06.078Z",
+        finisheddate: null,
+        id: 4,
+        name: "taskName",
+        comment: "taskComment",
+        groupid: 1,
+        updatedAt: expect.anything(),
+        createdAt: expect.anything()
+      } */
     ]);
   });
 
@@ -661,7 +689,20 @@ describe("/tasks", () => {
     });
   });
 
-  it("PUT /authed/tasks/1", async () => {
+  it("PUT /authed/tasks/100 (not found) (bad request)", async () => {
+    const reqBody = {
+      name: "newTaskName",
+      comment: "taskComment"
+    };
+    const res = await req
+      .put("/api/v1/authed/tasks/100")
+      .set("Authorization", `Bearer ${bearerUser1}`)
+      .send(reqBody);
+    expect(res.status).toBe(404);
+    expect(res.body.errorCode).toEqual(1617);
+  });
+
+  it("PUT /authed/tasks/1 change name", async () => {
     const reqBody = {
       name: "newTaskName"
     };
@@ -684,20 +725,7 @@ describe("/tasks", () => {
     });
   });
 
-  it("PUT /authed/tasks/100 (wrong, not found)", async () => {
-    const reqBody = {
-      name: "newTaskName",
-      comment: "taskComment"
-    };
-    const res = await req
-      .put("/api/v1/authed/tasks/100")
-      .set("Authorization", `Bearer ${bearerUser1}`)
-      .send(reqBody);
-    expect(res.status).toBe(404);
-    expect(res.body.errorCode).toEqual(1617);
-  });
-
-  it("PUT /authed/tasks/1 comment, isfinished", async () => {
+  it("PUT /authed/tasks/1 comment and isfinished", async () => {
     const reqBody = {
       comment: "newTaskComment",
       isfinished: true
@@ -721,7 +749,7 @@ describe("/tasks", () => {
     });
   });
 
-  it("PUT /authed/tasks/1 whoisdoinguserid is invalid", async () => {
+  it("PUT /authed/tasks/1 whoisdoinguserid is string (bad request)", async () => {
     const reqBody = {
       whoisdoinguserid: "isNotNumber"
     };
@@ -733,9 +761,9 @@ describe("/tasks", () => {
     expect(res.body.errorCode).toBe(1703);
   });
 
-  it("PUT /authed/tasks/1 whoisdoinguserid is invalid", async () => {
+  it("PUT /authed/tasks/1 whoisdoinguserid 's user is not found (bad request)", async () => {
     const reqBody = {
-      whoisdoinguserid: 5
+      whoisdoinguserid: 100
     };
     const res = await req
       .put("/api/v1/authed/tasks/1")
@@ -745,7 +773,7 @@ describe("/tasks", () => {
     expect(res.body.errorCode).toBe(1621);
   });
 
-  it("PUT /authed/tasks/1 whoisdoinguserid is invalid", async () => {
+  it("PUT /authed/tasks/1 whoisdoinguserid 's user is not join any groups (bad request)", async () => {
     const reqBody = {
       whoisdoinguserid: 4
     };
@@ -757,7 +785,7 @@ describe("/tasks", () => {
     expect(res.body.errorCode).toBe(1621);
   });
 
-  it("PUT /authed/tasks/1 whoisdoinguserid is invalid", async () => {
+  it("PUT /authed/tasks/1 whoisdoinguserid 's user is not join same group (bad request)", async () => {
     const reqBody = {
       whoisdoinguserid: 3
     };
@@ -795,6 +823,76 @@ describe("/tasks", () => {
   it("PUT /authed/tasks/1 whoisdoinguserid is null", async () => {
     const reqBody = {
       whoisdoinguserid: null
+    };
+    const res = await req
+      .put("/api/v1/authed/tasks/1")
+      .set("Authorization", `Bearer ${bearerUser1}`)
+      .send(reqBody);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      whoisdoinguserid: null,
+      isfinished: true,
+      deadlinedate: null,
+      finisheddate: null,
+      id: 1,
+      name: "newTaskName",
+      comment: "newTaskComment",
+      groupid: 1,
+      updatedAt: expect.anything(),
+      createdAt: expect.anything()
+    });
+  });
+
+  it("PUT /authed/tasks/1 deadlinedate (is not string) (bad request)", async () => {
+    const reqBody = {
+      deadlinedate: 0
+    };
+    const res = await req
+      .put("/api/v1/authed/tasks/1")
+      .set("Authorization", `Bearer ${bearerUser1}`)
+      .send(reqBody);
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(1705);
+  });
+
+  it("PUT /authed/tasks/1 deadlinedate (is not date string(ISO8601)) (bad request)", async () => {
+    const reqBody = {
+      deadlinedate: "isNotDateString(ISO8601)"
+    };
+    const res = await req
+      .put("/api/v1/authed/tasks/1")
+      .set("Authorization", `Bearer ${bearerUser1}`)
+      .send(reqBody);
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(1706);
+  });
+
+  it("PUT /authed/tasks/1 deadlinedate", async () => {
+    const reqBody = {
+      deadlinedate: "2021-02-03T04:05:06.078Z"
+    };
+    const res = await req
+      .put("/api/v1/authed/tasks/1")
+      .set("Authorization", `Bearer ${bearerUser1}`)
+      .send(reqBody);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      whoisdoinguserid: null,
+      isfinished: true,
+      deadlinedate: "2021-02-03T04:05:06.078Z",
+      finisheddate: null,
+      id: 1,
+      name: "newTaskName",
+      comment: "newTaskComment",
+      groupid: 1,
+      updatedAt: expect.anything(),
+      createdAt: expect.anything()
+    });
+  });
+
+  it("PUT /authed/tasks/1 deadlinedate(null)", async () => {
+    const reqBody = {
+      deadlinedate: null
     };
     const res = await req
       .put("/api/v1/authed/tasks/1")

--- a/__test__/test.ts
+++ b/__test__/test.ts
@@ -120,7 +120,7 @@ describe("/login", () => {
     });
     expect(res.body.token.length).toBe(66);
     bearerUser1 = res.body.token;
-    console.log(`bearer token user1 : ${bearerUser1}`);
+    // console.log(`bearer token user1 : ${bearerUser1}`);
   });
 
   it("user2", async () => {
@@ -139,7 +139,7 @@ describe("/login", () => {
     });
     expect(res.body.token.length).toBe(66);
     bearerUser2 = res.body.token;
-    console.log(`bearer token user2 : ${bearerUser2}`);
+    // console.log(`bearer token user2 : ${bearerUser2}`);
   });
 
   it("user3", async () => {
@@ -150,7 +150,7 @@ describe("/login", () => {
     const res = await req.post("/api/v1/login").send(reqBody);
     expect(res.status).toBe(200);
     bearerUser3 = res.body.token;
-    console.log(`bearer token user3 : ${bearerUser3}`);
+    // console.log(`bearer token user3 : ${bearerUser3}`);
   });
 
   it("user4", async () => {
@@ -161,7 +161,7 @@ describe("/login", () => {
     const res = await req.post("/api/v1/login").send(reqBody);
     expect(res.status).toBe(200);
     bearerUser4 = res.body.token;
-    console.log(`bearer token user4 : ${bearerUser4}`);
+    // console.log(`bearer token user4 : ${bearerUser4}`);
   });
 
   it("user1 wrong password (will fail)", async () => {
@@ -730,7 +730,7 @@ describe("/tasks", () => {
       .set("Authorization", `Bearer ${bearerUser1}`)
       .send(reqBody);
     expect(res.status).toBe(400);
-    expect(res.body.errorCode).toBe(1707);
+    expect(res.body.errorCode).toBe(1703);
   });
 
   it("PUT /authed/tasks/1 whoisdoinguserid is invalid", async () => {

--- a/documents/specification/detail/task.md
+++ b/documents/specification/detail/task.md
@@ -28,7 +28,7 @@ GET /authed/tasks
 | groupid | 数字 | タスクの所属するグループid |
 | isfinished | 真偽値 | タスクが完了したか否か |
 | whoisdoinguserid | 数字またはnull | タスク担当者のユーザid(担当者未定の場合はnull) |
-| deadlinedate | null | タスクの締め切り日時を表す予定のフィールド(現在未使用) |
+| deadlinedate | 文字列またはnull | タスクの締め切り日時 |
 | finisheddate | null | タスクを完了にした日時を表す予定のフィールド(現在未使用) |
 | updatedAt | 文字列 | 当該レコードの最終更新日時(タイムゾーンなし) |
 | createdAt | 文字列 | 当該レコードの作成日時(タイムゾーンなし) |
@@ -54,6 +54,7 @@ GET /authed/tasks
 | name | 文字列 | 必須 | タスクの表示名 |
 | comment | 文字列またはnull | 任意 | タスクの詳細文字列 |
 | whoisdoinguserid | 数字またはnull | 任意 | タスクを担当するユーザid(必ずリクエストを送信しているユーザ、タスクと同じグループに属するユーザでなければならない) |
+| deadlinedate | 文字列またはnull | 任意 | タスクの締め切り日時(ISO8601) |
 
 ### レスポンスbody
 
@@ -65,7 +66,7 @@ GET /authed/tasks
 | groupid | 数字 | タスクの所属するグループid |
 | isfinished | 真偽値 | タスクが完了したか否か(タスク作成時はデフォルトでfalseが設定される) |
 | whoisdoinguserid | 数字またはnull | タスク担当者のユーザid(担当者未定の場合はnull) |
-| deadlinedate | null | タスクの締め切り日時を表す予定のフィールド(現在未使用) |
+| deadlinedate | 文字列またはnull | タスクの締め切り日時(ISO8601) |
 | finisheddate | null | タスクを完了にした日時を表す予定のフィールド(現在未使用) |
 | updatedAt | 文字列 | 当該レコードの最終更新日時(タイムゾーンなし) |
 | createdAt | 文字列 | 当該レコードの作成日時(タイムゾーンなし) |
@@ -101,7 +102,7 @@ GET /authed/tasks
 | groupid | 数字 | タスクの所属するグループid |
 | isfinished | 真偽値 | タスクが完了したか否か |
 | whoisdoinguserid | 数字またはnull | タスク担当者のユーザid(担当者未定の場合はnull) |
-| deadlinedate | null | タスクの締め切り日時を表す予定のフィールド(現在未使用) |
+| deadlinedate | 文字列またはnull | タスクの締め切り日時(ISO8601) |
 | finisheddate | null | タスクを完了にした日時を表す予定のフィールド(現在未使用) |
 | updatedAt | 文字列 | 当該レコードの最終更新日時(タイムゾーンなし) |
 | createdAt | 文字列 | 当該レコードの作成日時(タイムゾーンなし) |
@@ -128,6 +129,7 @@ GET /authed/tasks
 | comment | 文字列またはnull | 任意 | タスクの詳細文字列 |
 | isfinished | 真偽値 | 任意 | タスクが完了したか否か |
 | whoisdoinguserid | 数字またはnull | 任意 | タスクを担当するユーザid(必ずリクエストを送信しているユーザ、タスクと同じグループに属するユーザでなければならない) |
+| deadlinedate | 文字列またはnull | 任意 | タスクの締め切り日時(ISO8601) |
 
 ### レスポンスbody
 
@@ -139,7 +141,7 @@ GET /authed/tasks
 | groupid | 数字 | タスクの所属するグループid |
 | isfinished | 真偽値 | タスクが完了したか否か |
 | whoisdoinguserid | 数字またはnull | タスク担当者のユーザid(担当者未定の場合はnull) |
-| deadlinedate | null | タスクの締め切り日時を表す予定のフィールド(現在未使用) |
+| deadlinedate | 文字列またはnull | タスクの締め切り日時(ISO8601) |
 | finisheddate | null | タスクを完了にした日時を表す予定のフィールド(現在未使用) |
 | updatedAt | 文字列 | 当該レコードの最終更新日時(タイムゾーンなし) |
 | createdAt | 文字列 | 当該レコードの作成日時(タイムゾーンなし) |

--- a/src/middleware/typeCheck.ts
+++ b/src/middleware/typeCheck.ts
@@ -1,131 +1,110 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-throw-literal */
+/* eslint-disable valid-typeof */
+
 import * as express from "express";
 import errorHandle from "../others/error";
 
-const isNumber = (val: any): boolean => {
-  if (
-    typeof val === "number" &&
-    !Number.isNaN(val) &&
-    val > 0 &&
-    val === Math.floor(val)
-  ) {
-    return true;
-  }
-  return false;
-};
-
-const isString = (val: any): boolean => {
-  if (typeof val === "string" && val !== "") {
-    return true;
-  }
-  return false;
-};
-
-const isEmptyString = (val: any): boolean => {
-  if (val === "") {
-    return true;
-  }
-  return false;
-};
-
-const isBoolean = (val: any): boolean => {
-  if (val === true || val === false) {
-    return true;
-  }
-  return false;
-};
-
-const isEmpty = (val: any): boolean => {
-  if (val === null || val === undefined) {
-    return true;
-  }
-  return false;
-};
-
-/*
-const isstrboolean = (val:any):boolean => {
-    if( val === "true" || val === "false" ){
-      return true;
-    }
-    return false;
+interface RequestBody {
+  email?: string;
+  password?: string;
+  name?: string | null;
+  inviteeuserid?: number;
+  message?: string | null;
+  comment?: string | null;
+  isfinished?: boolean;
+  whoisdoinguserid?: number | null;
+  deadlinedate?: Date | null;
 }
-*/
+
+const validate = (
+  val: any,
+  allowNull: boolean,
+  allowUndefined: boolean,
+  typeString: string,
+  errorCode: number
+): any => {
+  if (allowNull && val === null) {
+    return null;
+  }
+  if (allowUndefined && val === undefined) {
+    return undefined;
+  }
+  if (typeof val !== typeString) {
+    throw errorCode;
+  }
+  if (
+    typeString === "number" &&
+    (Number.isNaN(val) || Math.floor(val) !== val)
+  ) {
+    throw errorCode;
+  }
+  return val;
+};
+
+const stringOrUndefined = (val: any): string | undefined => {
+  return validate(val, false, true, "string", 1700);
+};
+
+const stringOrNullOrUndefined = (val: any): string | null | undefined => {
+  return validate(val, true, true, "string", 1701);
+};
+
+const numberOrUndefined = (val: any): number | undefined => {
+  return validate(val, false, true, "number", 1702);
+};
+
+const numberOrNullOrUndefined = (val: any): number | null | undefined => {
+  return validate(val, true, true, "number", 1703);
+};
+
+const booleanOrUndefined = (val: any): boolean | undefined => {
+  return validate(val, false, true, "boolean", 1704);
+};
+
+const dateOrNullOrUndefined = (val: any): Date | null | undefined => {
+  if (val === null || val === undefined) {
+    return val;
+  }
+  if (typeof val !== "string") {
+    throw 1705;
+  }
+  const strISO8601: string = val;
+  const milliSecond: number = Date.parse(strISO8601);
+  if (Number.isNaN(milliSecond)) {
+    throw 1706;
+  }
+  return new Date(milliSecond);
+};
 
 const validateReqBody = (
   req: express.Request,
   res: express.Response,
   next: Function
 ): void => {
-  if (false) {
-    console.log(req);
-    console.log(res);
-  }
+  let body: RequestBody = {};
 
-  const {
-    email, // string
-    password, // string
-    name, // string or undefined
-    inviteeuserid, // number
-    message, // string or undefined
-    comment, // string or undefined
-    isfinished, // boolean or undefined
-    whoisdoinguserid // number or null or undefined
-  } = req.body;
-
-  const validated = {
-    email, // string
-    password, // string
-    name, // string or undefined
-    inviteeuserid, // number
-    message, // string or undefined
-    comment, // string or undefined
-    isfinished, // boolean or undefined
-    whoisdoinguserid
-  };
-
-  req.body = validated;
-
-  if (
-    !isEmpty(validated.email) &&
-    (!isString(validated.email) || isEmptyString(validated.email))
-  ) {
-    errorHandle(res, 1700);
-    return;
-  }
-  if (
-    !isEmpty(validated.password) &&
-    (!isString(validated.password) || isEmptyString(validated.password))
-  ) {
-    errorHandle(res, 1701);
-    return;
-  }
-  if (!isEmpty(validated.name) && !isString(validated.name)) {
-    errorHandle(res, 1702);
-    return;
-  }
-  if (!isEmpty(validated.inviteeuserid) && !isNumber(validated.inviteeuserid)) {
-    errorHandle(res, 1703);
-    return;
-  }
-  if (!isEmpty(validated.message) && !isString(validated.message)) {
-    errorHandle(res, 1704);
-    return;
-  }
-  if (!isEmpty(validated.comment) && !isString(validated.comment)) {
-    errorHandle(res, 1705);
-    return;
-  }
-  if (!isEmpty(validated.isfinished) && !isBoolean(validated.isfinished)) {
-    errorHandle(res, 1706);
-    return;
-  }
-  if (
-    !isEmpty(validated.whoisdoinguserid) &&
-    !isNumber(validated.whoisdoinguserid)
-  ) {
+  try {
+    body = {
+      email: stringOrUndefined(req.body.email),
+      password: stringOrUndefined(req.body.password),
+      name: stringOrNullOrUndefined(req.body.name),
+      inviteeuserid: numberOrUndefined(req.body.inviteeuserid),
+      message: stringOrNullOrUndefined(req.body.message),
+      comment: stringOrNullOrUndefined(req.body.comment),
+      isfinished: booleanOrUndefined(req.body.isfinished),
+      whoisdoinguserid: numberOrNullOrUndefined(req.body.whoisdoinguserid),
+      deadlinedate: dateOrNullOrUndefined(req.body.deadlinedate)
+    };
+  } catch (e) {
+    if (e >= 1700 && e <= 1706) {
+      errorHandle(res, e);
+      return;
+    }
     errorHandle(res, 1707);
-    return;
   }
 
+  req.body = body;
   next();
 };
 

--- a/src/routes/v1/authed/tasks.ts
+++ b/src/routes/v1/authed/tasks.ts
@@ -9,6 +9,7 @@ interface TaskRequest {
   groupid?: number;
   isfinished?: boolean;
   whoisdoinguserid?: number;
+  deadlinedate?: Date | null;
 }
 const router = express.Router();
 
@@ -32,13 +33,20 @@ router.get("/", (req, res) => {
 // POST https://lovelab.2n2n.ninja/api/v1/tasks
 //  タスクを追加 自分の所属するグループのみ追加可能
 router.post("/", (req, res) => {
-  const { groupidAuth, name, comment, whoisdoinguserid } = req.body;
+  const {
+    groupidAuth,
+    name,
+    comment,
+    whoisdoinguserid,
+    deadlinedate
+  } = req.body;
   // TODO: deadlinedate, finisheddateを受け取って型変換する。(あとでデータベースに詰め込めるようにする)
   const taskRequest: TaskRequest = {
     name,
     comment,
     groupid: groupidAuth,
-    whoisdoinguserid
+    whoisdoinguserid,
+    deadlinedate
   };
 
   if (name === null || name === undefined) {
@@ -112,26 +120,24 @@ router.put("/:taskid", (req, res) => {
     return;
   }
 
-  const { groupidAuth, name, isfinished, comment, whoisdoinguserid } = req.body;
+  const {
+    groupidAuth,
+    name,
+    isfinished,
+    comment,
+    whoisdoinguserid,
+    deadlinedate
+  } = req.body;
   // TODO: Deadline, finishedlineを扱えるようにする
   // TODO: name, commentのSQLインジェクション可能性排除
 
-  const taskRequest: TaskRequest = {};
-  if (name !== undefined) {
-    taskRequest.name = name;
-  }
-  if (comment !== undefined) {
-    taskRequest.comment = comment;
-  }
-  if (isfinished === true || isfinished === false) {
-    taskRequest.isfinished = isfinished;
-  } else if (isfinished !== undefined) {
-    errorHandle(res, 1615);
-    return;
-  }
-  if (whoisdoinguserid !== undefined) {
-    taskRequest.whoisdoinguserid = whoisdoinguserid;
-  }
+  const taskRequest: TaskRequest = {
+    name,
+    comment,
+    isfinished,
+    whoisdoinguserid,
+    deadlinedate
+  };
 
   new Promise((resolve, reject) => { // eslint-disable-line
     if (


### PR DESCRIPTION
`/api/v1/authed/tasks`以下に GET/POST/PUT するときのリクエスト/レスポンスどちらものbodyのプロパティに`deadlinedate`を有効化した。

## POST/PUTのリクエストbody

`deadlinedate` ... 文字列またはnull, 任意, ISO8601形式

## GET/POST/PUTのレスポンスbody

`deadlinedate` ... 文字列またはnull, ISO8601形式