### PR TITLE
招待をPOST/GETしたとき、groupnameを一緒に返す。

### DIFF
--- a/__test__/test.ts
+++ b/__test__/test.ts
@@ -306,6 +306,7 @@ describe("/authed/invitations", () => {
     expect(res.body).toEqual({
       id: 1,
       groupid: 1,
+      groupname: "groupname",
       inviteruserid: 1,
       inviteeuserid: 2,
       message: "invitation message",
@@ -326,6 +327,7 @@ describe("/authed/invitations", () => {
     expect(res.body).toEqual({
       id: 2,
       groupid: 1,
+      groupname: "groupname",
       inviteruserid: 1,
       inviteeuserid: 2,
       message: null,
@@ -344,6 +346,7 @@ describe("/authed/invitations", () => {
       {
         id: 1,
         groupid: 1,
+        groupname: "groupname",
         inviteruserid: 1,
         inviteeuserid: 2,
         message: "invitation message",
@@ -353,6 +356,7 @@ describe("/authed/invitations", () => {
       {
         id: 2,
         groupid: 1,
+        groupname: "groupname",
         inviteruserid: 1,
         inviteeuserid: 2,
         message: null,

--- a/documents/specification/detail/invitation.md
+++ b/documents/specification/detail/invitation.md
@@ -30,6 +30,7 @@ inviteeは必ずグループに所属していない(groupid=null)である必�
 | message | 文字列またはnull | 招待相手に見せるメッセージ |
 | id | 数字 | 招待id |
 | groupid | 数字 | 招待先のグループ |
+| groupname | 文字列 | 招待先のグループ名 |
 | inviteruserid | 数字 | 招待者(既にグループに加入している人)のユーザid |
 | inviteeuserid | 数字 | 被招待者(まだグループに加入していない人)のユーザid |
 | updatedAt | 文字列 | この招待レコードが更新された日時を表す タイムゾーンなし |
@@ -60,6 +61,7 @@ inviteeは必ずグループに所属していない(groupid=null)である必�
 | message | 文字列またはnull | 招待相手に見せるメッセージ |
 | id | 数字 | 招待id |
 | groupid | 数字 | 招待先のグループ |
+| groupname | 文字列 | 招待先のグループ名 |
 | inviteruserid | 数字 | 招待者(既にグループに加入している人)のユーザid |
 | inviteeuserid | 数字 | 被招待者(まだグループに加入していない人)のユーザid |
 | updatedAt | 文字列 | この招待レコードが更新された日時を表す タイムゾーンなし |


### PR DESCRIPTION
- GET /api/v1/invitations
- POST /api/v1/invitations

以上のエンドポイントのレスポンスボディに`groupname`を追加した。
